### PR TITLE
Fixed a bug where pausing did not work even when selecting Always pause

### DIFF
--- a/image_chooser_preview.py
+++ b/image_chooser_preview.py
@@ -65,9 +65,13 @@ class BaseChooser(PreviewImage):
     def IS_CHANGED(cls, id, **kwargs):
         mode = kwargs.get("mode", ["Always pause"])
         node_id = str(id[0])
-        if mode[0] != "Repeat last selection" or node_id not in cls._last_ic:
+        if mode[0] == "Repeat last selection" and node_id in cls._last_ic:
+            return cls._last_ic[node_id]
+        elif mode[0] == "Always pause":
+            return 0.0
+        else:
             cls._last_ic[node_id] = random.random()
-        return cls._last_ic[node_id]
+            return cls._last_ic[node_id]
 
     def chooser_type(self) -> str:
         return "single"
@@ -136,7 +140,8 @@ class BaseChooser(PreviewImage):
             selection = list(range(start, batch))
         elif mode == "Only pause if batch" and batch <= 1:
             selection = [0]
-
+        elif mode == "Always pause":
+            selection = None
         preview_payload = images_tensor
         ret = self.save_images(images=preview_payload, **kwargs)
 


### PR DESCRIPTION
This is exactly the divine node I've been looking for.
Thank you for creating it.

However, I found a bug where selecting “Always pause” in the Image Chooser Classic node didn't actually pause it, so I fixed it.
Please merge it if you see fit.