### PR TITLE
Add new "Repeat last cached selection" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Restart (or hard-refresh) ComfyUI so the new JavaScript files load. The **Add No
 - **Classic node** - keeps everything in the graph. The widget automatically resizes to show the entire batch.
 - **Hotkeys** - the chooser listens for 1-9 to toggle thumbnails, 0 to progress/cancel, and Esc to cancel.
 
+## Modes
+
+| Mode | Behaviour |
+|------|-----------|
+| **Always pause** | The chooser dialog opens on every run, regardless of what changed. This mode will cause all downstream nodes to re-run. |
+| **Repeat last selection** | After you pick once, subsequent runs apply the same selection *index* to whatever images are present, including new images. |
+| **Repeat last cached selection** | Like *Repeat last selection*, but also watches the image content. If the upstream images are identical to the previous run, the selection is repeated; if new images arrive, you can make a fresh choice. |
+| **Only pause if batch** | Skips the dialog when there is only a single image and auto-selects it; pauses to ask when there are two or more. |
+| **Progress first pick** | Pauses on the very first run; after that the workflow progresses automatically without asking again. |
+| **Pass through** | Never pauses — all images in the batch are forwarded downstream unchanged. |
+| **Take First n** | Silently selects the first *n* images (where *n* is the **count** widget value) without showing the dialog. |
+| **Take Last n** | Silently selects the last *n* images without showing the dialog. |
+
 ## Differences from the original project
 
 - No extraneous build metadata or auxiliary nodes – just the two chooser implementations.

--- a/image_chooser_preview.py
+++ b/image_chooser_preview.py
@@ -38,6 +38,7 @@ class BaseChooser(PreviewImage):
     FUNCTION = "func"
 
     _last_ic: Dict[str, float] = {}
+    _last_image_fingerprint: Dict[str, object] = {}
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -47,6 +48,7 @@ class BaseChooser(PreviewImage):
                     [
                         "Always pause",
                         "Repeat last selection",
+                        "Repeat last cached selection",
                         "Only pause if batch",
                         "Progress first pick",
                         "Pass through",
@@ -70,7 +72,7 @@ class BaseChooser(PreviewImage):
     def IS_CHANGED(cls, id, **kwargs):
         mode = kwargs.get("mode", ["Always pause"])
         node_id = str(id[0])
-        if mode[0] != "Repeat last selection" or node_id not in cls._last_ic:
+        if mode[0] not in ("Repeat last selection", "Repeat last cached selection") or node_id not in cls._last_ic:
             cls._last_ic[node_id] = random.random()
         return cls._last_ic[node_id]
 
@@ -138,11 +140,18 @@ class BaseChooser(PreviewImage):
         for key in list(kwargs.keys()):
             kwargs[key] = kwargs[key][0]
 
+        image_fingerprint = None
+        if mode == "Repeat last cached selection":
+            image_fingerprint = tuple((tuple(img.shape), img.sum().item()) for img in flat_images)
+
         selection: Optional[List[int]] = None
         last_selection = MessageBroker.get_last_selection(unique_id)
 
         if mode == "Repeat last selection" and last_selection:
             selection = list(last_selection)
+        elif mode == "Repeat last cached selection":
+            if last_selection and self._last_image_fingerprint.get(unique_id) == image_fingerprint:
+                selection = list(last_selection)
         elif mode == "Pass through":
             selection = list(range(batch))
         elif mode == "Take First n":
@@ -179,6 +188,8 @@ class BaseChooser(PreviewImage):
 
         selection = [idx for idx in selection if idx >= 0]
         MessageBroker.set_last_selection(unique_id, selection)
+        if image_fingerprint is not None:
+            self._last_image_fingerprint[unique_id] = image_fingerprint
 
         all_segments = []
         segs_shape = None

--- a/image_chooser_preview.py
+++ b/image_chooser_preview.py
@@ -33,6 +33,7 @@ def _flatten_latents(latents_in: Optional[Sequence[Dict]]) -> List[Dict[str, tor
 
 class BaseChooser(PreviewImage):
     CATEGORY = "image_chooser"
+    DESCRIPTION = "Pauses the workflow so you can choose images from a batch and forward matching outputs."
     INPUT_IS_LIST = True
     OUTPUT_NODE = False
     FUNCTION = "func"
@@ -268,6 +269,7 @@ class BaseChooser(PreviewImage):
 class PreviewAndChooseClassic(BaseChooser):
     RETURN_TYPES = ("IMAGE", "LATENT", "MASK", "STRING", "SEGS")
     RETURN_NAMES = ("images", "latents", "masks", "selected", "segs")
+    DESCRIPTION = "Inline classic chooser widget that pauses execution for manual image selection."
 
     def chooser_type(self) -> str:
         return "classic_widget"
@@ -279,11 +281,13 @@ class PreviewAndChooseClassic(BaseChooser):
 class PreviewAndChoose(BaseChooser):
     RETURN_TYPES = ("IMAGE", "LATENT", "MASK", "STRING", "SEGS")
     RETURN_NAMES = ("images", "latents", "masks", "selected", "segs")
+    DESCRIPTION = "Overlay chooser that pauses execution so you can select one or more images."
 
 
 class SimpleChooser(PreviewAndChoose):
     RETURN_TYPES = ("IMAGE", "LATENT")
     RETURN_NAMES = ("images", "latents")
+    DESCRIPTION = "Lightweight chooser that returns selected images and latents only."
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -301,6 +305,7 @@ class SimpleChooser(PreviewAndChoose):
 class PreviewAndChooseDouble(BaseChooser):
     RETURN_TYPES = ("LATENT", "LATENT")
     RETURN_NAMES = ("positive", "negative")
+    DESCRIPTION = "Split selected batch items into positive and negative latent groups."
 
     def chooser_type(self) -> str:
         return "double"

--- a/image_chooser_preview.py
+++ b/image_chooser_preview.py
@@ -166,6 +166,12 @@ class BaseChooser(PreviewImage):
         preview_payload = flat_images
         ret = self.save_images(images=preview_payload, **kwargs)
 
+        aspect_ratio: Optional[float] = None
+        if flat_images:
+            h, w = flat_images[0].shape[0], flat_images[0].shape[1]
+            if h > 0 and w > 0:
+                aspect_ratio = w / h
+
         context = {
             "unique_id": unique_id,
             "display_id": display_id,
@@ -178,6 +184,7 @@ class BaseChooser(PreviewImage):
             "has_latents": len(flat_latents) > 0,
             "has_masks": len(flat_masks) > 0,
             "has_segs": doing_segs,
+            "aspect_ratio": aspect_ratio,
         }
 
         if selection is None:

--- a/js/image_chooser.js
+++ b/js/image_chooser.js
@@ -17,6 +17,15 @@ function ensureSettings() {
         type: "boolean",
         defaultValue: true,
     });
+    app.ui.settings.addSetting({
+        id: "ImageChooser.thumbnailRightClick",
+        name: "Thumbnail Right Click",
+        type: "combo",
+        options: ["Browser Default", "ComfyUI Node", "Open Image"],
+        defaultValue: "Browser Default",
+        tooltip:
+            "Choose what happens when right clicking a thumbnail. Browser Default opens your browser's context menu, ComfyUI Node opens the node's context menu, and Open Image opens the image in a new tab.",
+    });
 }
 
 const alertAudio = new Audio("extensions/image-chooser-classic/ding.mp3");

--- a/js/image_chooser_preview.js
+++ b/js/image_chooser_preview.js
@@ -138,6 +138,13 @@ function injectStyles() {
     .cg-btn-cancel:hover {
         background: #b33a3a;
     }
+    .cg-btn-rerun {
+        background: #2f3138;
+        color: #f2f2f2;
+    }
+    .cg-btn-rerun:hover {
+        background: #8a6a00;
+    }
     .cg-btn-progress {
         background: #4caf50;
         color: #0f0f0f;
@@ -200,6 +207,7 @@ function openChooser(event) {
         grid: null,
         progressButton: null,
         cancelButton: null,
+        rerunButton: null,
         sending: false,
     };
 
@@ -278,6 +286,15 @@ function openChooser(event) {
         closeChooser("cancel");
     });
 
+    const rerunBtn = document.createElement("button");
+    rerunBtn.className = "cg-btn-rerun";
+    rerunBtn.textContent = "Rerun";
+    rerunBtn.addEventListener("click", () => {
+        send_cancel();
+        closeChooser("rerun");
+        app.queuePrompt(0, 1);
+    });
+
     const progressBtn = document.createElement("button");
     progressBtn.className = "cg-btn-progress";
     progressBtn.textContent = "Progress";
@@ -286,8 +303,10 @@ function openChooser(event) {
 
     session.progressButton = progressBtn;
     session.cancelButton = cancelBtn;
+    session.rerunButton = rerunBtn;
 
     actions.appendChild(cancelBtn);
+    actions.appendChild(rerunBtn);
     actions.appendChild(progressBtn);
 
     panel.appendChild(header);

--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -3,10 +3,225 @@ import { api } from "../../scripts/api.js";
 import { send_message, send_cancel } from "./image_chooser_messaging.js";
 
 const EVENT_NAME = "cg-image-chooser-classic-widget-channel";
+const THUMBNAIL_RIGHT_CLICK_SETTING_ID = "ImageChooser.thumbnailRightClick";
+const THUMBNAIL_RIGHT_CLICK_DEFAULT = "Browser Default";
 const activeWidgets = new Map();
 let currentActiveNode = null;
 const FALLBACK_ASPECT = 1;
 const MIN_CELL_EDGE = 1;
+let middleDragActive = false;
+let middleDragPointerId = null;
+
+function canElementScroll(el, deltaY, deltaX) {
+    if (!(el instanceof HTMLElement)) return false;
+
+    const style = getComputedStyle(el);
+    const overflowY = style.overflowY;
+    const overflowX = style.overflowX;
+
+    const canScrollY =
+        (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+        el.scrollHeight > el.clientHeight + 1;
+    const canScrollX =
+        (overflowX === "auto" || overflowX === "scroll" || overflowX === "overlay") &&
+        el.scrollWidth > el.clientWidth + 1;
+
+    if (canScrollY && deltaY !== 0) {
+        if (deltaY < 0 && el.scrollTop > 0) return true;
+        const maxY = el.scrollHeight - el.clientHeight;
+        if (deltaY > 0 && el.scrollTop < maxY) return true;
+    }
+
+    if (canScrollX && deltaX !== 0) {
+        if (deltaX < 0 && el.scrollLeft > 0) return true;
+        const maxX = el.scrollWidth - el.clientWidth;
+        if (deltaX > 0 && el.scrollLeft < maxX) return true;
+    }
+
+    return false;
+}
+
+function shouldUseLocalScroll(startEl, boundaryEl, deltaY, deltaX) {
+    let node = startEl;
+    while (node && node !== boundaryEl) {
+        if (canElementScroll(node, deltaY, deltaX)) return true;
+        node = node.parentElement;
+    }
+    return canElementScroll(boundaryEl, deltaY, deltaX);
+}
+
+function getComfyCanvas() {
+    const canvas = app?.canvas ?? window?.app?.canvas;
+    return canvas ?? null;
+}
+
+function getGraphCanvasElement() {
+    const direct = app?.canvas?.canvas;
+    if (direct instanceof HTMLCanvasElement) return direct;
+
+    const nested = app?.canvas?.canvas?.canvas;
+    if (nested instanceof HTMLCanvasElement) return nested;
+
+    return document.querySelector("canvas") ?? null;
+}
+
+function forwardCanvasEvent(kind, event) {
+    const canvas = getComfyCanvas();
+    const methodMap = {
+        wheel: "processMouseWheel",
+        down: "processMouseDown",
+        move: "processMouseMove",
+        up: "processMouseUp",
+    };
+    const methodName = methodMap[kind];
+    if (canvas && typeof canvas[methodName] === "function") {
+        canvas[methodName](event);
+        return;
+    }
+
+    // Fallback for unusual environments where app.canvas handlers are unavailable.
+    const canvasEl = getGraphCanvasElement();
+    if (!canvasEl) return;
+
+    if (kind === "wheel") {
+        const forwarded = new WheelEvent("wheel", {
+            bubbles: true,
+            cancelable: true,
+            deltaX: event.deltaX,
+            deltaY: event.deltaY,
+            deltaZ: event.deltaZ,
+            deltaMode: event.deltaMode,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            screenX: event.screenX,
+            screenY: event.screenY,
+            ctrlKey: event.ctrlKey,
+            shiftKey: event.shiftKey,
+            altKey: event.altKey,
+            metaKey: event.metaKey,
+        });
+        canvasEl.dispatchEvent(forwarded);
+        return;
+    }
+
+    const typeMap = {
+        down: "mousedown",
+        move: "mousemove",
+        up: "mouseup",
+    };
+    const forwardedType = typeMap[kind];
+    const forwarded = new MouseEvent(forwardedType, {
+        bubbles: true,
+        cancelable: true,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        screenX: event.screenX,
+        screenY: event.screenY,
+        button: event.button,
+        buttons: event.buttons,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+    });
+    canvasEl.dispatchEvent(forwarded);
+}
+
+function handleWidgetWheel(event, container) {
+    if (shouldUseLocalScroll(event.target, container, event.deltaY, event.deltaX)) {
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    forwardCanvasEvent("wheel", event);
+}
+
+function stopMiddleDragForwarding() {
+    if (!middleDragActive) return;
+    middleDragActive = false;
+    middleDragPointerId = null;
+    window.removeEventListener("pointermove", handleWindowPointerMoveForPan, true);
+    window.removeEventListener("pointerup", handleWindowPointerUpForPan, true);
+    window.removeEventListener("pointercancel", handleWindowPointerUpForPan, true);
+    window.removeEventListener("blur", stopMiddleDragForwarding, true);
+}
+
+function handleWindowPointerMoveForPan(event) {
+    if (!middleDragActive) return;
+    if (middleDragPointerId !== null && event.pointerId !== middleDragPointerId) return;
+    if ((event.buttons & 4) !== 4) return;
+    event.preventDefault();
+    event.stopPropagation();
+    forwardCanvasEvent("move", event);
+}
+
+function handleWindowPointerUpForPan(event) {
+    if (!middleDragActive) return;
+    if (middleDragPointerId !== null && event.pointerId !== middleDragPointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    forwardCanvasEvent("up", event);
+    stopMiddleDragForwarding();
+}
+
+function handleWidgetPointerDown(event) {
+    // Forward middle-button drag to the graph canvas so pan works over the widget.
+    if (event.button !== 1) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    middleDragPointerId = event.pointerId;
+    forwardCanvasEvent("down", event);
+
+    if (!middleDragActive) {
+        middleDragActive = true;
+        window.addEventListener("pointermove", handleWindowPointerMoveForPan, true);
+        window.addEventListener("pointerup", handleWindowPointerUpForPan, true);
+        window.addEventListener("pointercancel", handleWindowPointerUpForPan, true);
+        window.addEventListener("blur", stopMiddleDragForwarding, true);
+    }
+}
+
+function handleWidgetAuxClick(event) {
+    if (event.button !== 1) return;
+    event.preventDefault();
+    event.stopPropagation();
+}
+
+
+function getThumbnailRightClickMode() {
+    if (!app?.ui?.settings) return THUMBNAIL_RIGHT_CLICK_DEFAULT;
+    return app.ui.settings.getSettingValue(
+        THUMBNAIL_RIGHT_CLICK_SETTING_ID,
+        THUMBNAIL_RIGHT_CLICK_DEFAULT
+    );
+}
+
+function openImageInNewTab(url) {
+    if (!url) return;
+    const newTab = window.open(url, "_blank", "noopener,noreferrer");
+    if (newTab) newTab.opener = null;
+}
+
+function handleThumbnailContextMenu(event, imageUrl) {
+    const mode = getThumbnailRightClickMode();
+
+    if (mode === "ComfyUI Node") {
+        // Let ComfyUI handle the node context menu.
+        return;
+    }
+
+    if (mode === "Open Image") {
+        event.preventDefault();
+        event.stopPropagation();
+        openImageInNewTab(imageUrl);
+        return;
+    }
+
+    // Browser Default: keep browser context menu, but stop node-level menu.
+    event.stopPropagation();
+}
 
 function ensureStyles() {
     if (document.getElementById("cg-image-chooser-widget-style")) return;
@@ -131,11 +346,31 @@ function ensureWidget(node) {
         cancelBtn: null,
         lastDetail: null,
         layout: null,
+        wheelHandler: null,
+        pointerDownHandler: null,
+        auxClickHandler: null,
     };
+
+    info.wheelHandler = (event) => handleWidgetWheel(event, container);
+    container.addEventListener("wheel", info.wheelHandler, { passive: false });
+    info.pointerDownHandler = (event) => handleWidgetPointerDown(event);
+    container.addEventListener("pointerdown", info.pointerDownHandler, { passive: false });
+    info.auxClickHandler = (event) => handleWidgetAuxClick(event);
+    container.addEventListener("auxclick", info.auxClickHandler, { passive: false });
+
     activeWidgets.set(node.id, info);
 
     const originalOnRemoved = node.onRemoved;
     node.onRemoved = function (...args) {
+        if (info.wheelHandler) {
+            container.removeEventListener("wheel", info.wheelHandler);
+        }
+        if (info.pointerDownHandler) {
+            container.removeEventListener("pointerdown", info.pointerDownHandler);
+        }
+        if (info.auxClickHandler) {
+            container.removeEventListener("auxclick", info.auxClickHandler);
+        }
         activeWidgets.delete(this.id);
         if (currentActiveNode === this) currentActiveNode = null;
         domWidget.onRemove?.();
@@ -485,6 +720,9 @@ function renderChooser(node, detail) {
                 updateThumbRatio(node, img.naturalWidth / img.naturalHeight);
             }
         });
+        cell.addEventListener("contextmenu", (event) => {
+            handleThumbnailContextMenu(event, img.src);
+        });
         cell.appendChild(img);
         cell.addEventListener("click", (event) => {
             event.preventDefault();
@@ -576,6 +814,7 @@ function handleKey(event) {
 }
 
 function clearWidgetState() {
+    stopMiddleDragForwarding();
     activeWidgets.forEach((info, nodeId) => {
         info.grid?.querySelectorAll(".cg-chooser-cell").forEach((cell) => cell.classList.remove("selected"));
         if (info.progressBtn) info.progressBtn.disabled = true;

--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -305,6 +305,10 @@ function ensureStyles() {
         background: #c54a4a;
         color: #fff;
     }
+    .cg-chooser-rerun {
+        background: #8a6a00;
+        color: #fff;
+    }
     `;
     document.head.appendChild(style);
 }
@@ -705,7 +709,17 @@ function renderChooser(node, detail) {
     });
     info.cancelBtn = cancelBtn;
 
+    const rerunBtn = document.createElement("button");
+    rerunBtn.className = "cg-chooser-rerun";
+    rerunBtn.textContent = "Rerun";
+    rerunBtn.addEventListener("click", () => {
+        send_cancel();
+        clearSelection(node);
+        app.queuePrompt(0, 1);
+    });
+
     footer.appendChild(cancelBtn);
+    footer.appendChild(rerunBtn);
     footer.appendChild(progressBtn);
     container.appendChild(stage);
     container.appendChild(footer);

--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -11,6 +11,14 @@ const FALLBACK_ASPECT = 1;
 const MIN_CELL_EDGE = 1;
 let middleDragActive = false;
 let middleDragPointerId = null;
+const alertAudio = new Audio("extensions/image-chooser-classic/ding.mp3");
+
+function playAlertIfEnabled() {
+    if (app?.ui?.settings?.getSettingValue("ImageChooser.alert", true)) {
+        alertAudio.currentTime = 0;
+        alertAudio.play().catch(() => {});
+    }
+}
 
 function canElementScroll(el, deltaY, deltaX) {
     if (!(el instanceof HTMLElement)) return false;
@@ -832,6 +840,7 @@ app.registerExtension({
     },
     setup() {
         api.addEventListener(EVENT_NAME, (evt) => {
+            playAlertIfEnabled();
             handleEvent(evt.detail ?? {});
         });
         api.addEventListener("execution_start", clearWidgetState);

--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -281,8 +281,7 @@ function ensureStyles() {
     }
     .cg-chooser-cell img {
         width: 100%;
-        height: auto;
-        max-height: 100%;
+        height: 100%;
         object-fit: contain;
         display: block;
     }
@@ -291,7 +290,6 @@ function ensureStyles() {
         flex: 0 0 auto;
         justify-content: flex-end;
         gap: 8px;
-        margin-top: 4px;
         overflow: hidden;
     }
     .cg-chooser-footer button {
@@ -354,8 +352,15 @@ function ensureWidget(node) {
             return null;
         },
         setValue() {},
+        hideOnZoom: false,
     });
     domWidget.serialize = false;
+    if (domWidget.element instanceof HTMLElement) {
+        domWidget.element.style.overflow = "hidden";
+        if (domWidget.element.parentElement instanceof HTMLElement) {
+            domWidget.element.parentElement.style.overflow = "hidden";
+        }
+    }
 
     info = {
         container,
@@ -425,33 +430,19 @@ function extractRatioFromDetail(detail) {
     return hint > 0 ? hint : null;
 }
 
-function updateThumbRatio(node, ratio) {
-    if (!Number.isFinite(ratio) || ratio <= 0) return;
-    const prev = Number(node._ic_thumb_ratio);
-    const delta = Math.abs((prev || FALLBACK_ASPECT) - ratio);
-    if (!prev || delta > 0.01) {
-        node._ic_thumb_ratio = ratio;
-        requestLayoutUpdate(node);
-    } else {
-        node._ic_thumb_ratio = ratio;
-    }
-}
-
 function getThumbRatio(node, detail) {
     const cached = Number(node?._ic_thumb_ratio);
     if (cached > 0) return cached;
     const derived = extractRatioFromDetail(detail);
-    if (derived && derived > 0) {
-        node._ic_thumb_ratio = derived;
-        return derived;
-    }
-    return FALLBACK_ASPECT;
+    const ratio = Number.isFinite(derived) && derived > 0 ? derived : FALLBACK_ASPECT;
+    node._ic_thumb_ratio = ratio;
+    return ratio;
 }
 
 function formatPx(value) {
     if (!Number.isFinite(value)) return "0px";
     if (value < 0) value = 0;
-    const rounded = Math.round(value * 100) / 100;
+    const rounded = Math.floor(value * 100) / 100;
     return `${rounded}px`;
 }
 
@@ -462,7 +453,7 @@ function determineLayout(node, detail) {
     const maxAutoHeight = 420;
     const baseGap = 6;
     const padding = 12;
-    const footerHeight = 42;
+    const footerHeight = 52;
     const ratio = getThumbRatio(node, detail);
 
     const size = node.size ?? [];
@@ -510,16 +501,14 @@ function determineLayout(node, detail) {
 
         const usedWidth = columns * cellWidth + (columns - 1) * columnGap;
         const usedHeight = rows * cellHeight + (rows - 1) * rowGap;
-        if (usedWidth > availableWidth + 0.5 || usedHeight > availableHeight + 0.5) {
-            continue;
-        }
+        if (usedWidth > availableWidth + 0.5 || usedHeight > availableHeight + 0.5) continue;
 
         const widthUsage = usedWidth / availableWidth;
         const heightUsage = usedHeight / availableHeight;
         const balance = Math.abs(columns - rows);
         const sizeScore = cellWidth * cellHeight;
         const fillPenalty = Math.abs(1 - widthUsage) + Math.abs(1 - heightUsage);
-        const score = sizeScore - fillPenalty * sizeScore * 0.1 - emptySlots * 0.01 - balance * 0.05;
+        const score = sizeScore - fillPenalty * sizeScore * 0.15 - emptySlots * 0.01 - balance * 0.05;
 
         if (!bestLayout || score > bestLayout.score) {
             bestLayout = {
@@ -537,7 +526,7 @@ function determineLayout(node, detail) {
     }
 
     if (!bestLayout) {
-        // Fallback: single column scaled to fit height
+        // Fallback: single column that fills the available space.
         const columnGap = Math.min(baseGap, availableWidth / 12);
         const rowGap = Math.min(baseGap, availableHeight / Math.max(imageCount * 2, 1));
         const rows = imageCount;
@@ -677,6 +666,11 @@ function requestLayoutUpdate(node) {
     });
 }
 
+function getCanvasZoom() {
+    const zoom = Number(app?.canvas?.ds?.scale);
+    return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+}
+
 function renderChooser(node, detail) {
     const info = ensureWidget(node);
     info.lastDetail = detail;
@@ -728,24 +722,37 @@ function renderChooser(node, detail) {
     container.appendChild(stage);
     container.appendChild(footer);
 
+    const sharedRatio = getThumbRatio(node, detail);
+    const cellAspect = Number.isFinite(sharedRatio) && sharedRatio > 0
+        ? `${sharedRatio}` : "1";
+
     node._ic_selection = new Set();
     (detail.urls ?? []).forEach((u, idx) => {
         const cell = document.createElement("div");
         cell.className = "cg-chooser-cell";
         cell.dataset.index = String(idx);
-        cell.style.aspectRatio = "1 / 1";
+        cell.style.aspectRatio = cellAspect;
 
         const img = document.createElement("img");
         img.src = api.apiURL(
             `/view?filename=${encodeURIComponent(u.filename)}&type=${u.type}&subfolder=${encodeURIComponent(u.subfolder ?? "")}`
         );
         img.alt = `Image ${idx + 1}`;
-        img.addEventListener("load", () => {
-            if (img.naturalWidth && img.naturalHeight) {
-                cell.style.aspectRatio = `${img.naturalWidth} / ${img.naturalHeight}`;
-                updateThumbRatio(node, img.naturalWidth / img.naturalHeight);
-            }
-        });
+        if (idx === 0) {
+            img.addEventListener("load", () => {
+                if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+                    const loadedRatio = img.naturalWidth / img.naturalHeight;
+                    if (Math.abs(loadedRatio - sharedRatio) > 0.01) {
+                        node._ic_thumb_ratio = loadedRatio;
+                        const newAspect = String(loadedRatio);
+                        info.grid?.querySelectorAll(".cg-chooser-cell").forEach((c) => {
+                            c.style.aspectRatio = newAspect;
+                        });
+                        requestLayoutUpdate(node);
+                    }
+                }
+            }, { once: true });
+        }
         cell.addEventListener("contextmenu", (event) => {
             handleThumbnailContextMenu(event, img.src);
         });
@@ -873,6 +880,21 @@ app.registerExtension({
             nodeType.prototype.onAdded = function (...args) {
                 const res = originalOnAdded?.apply(this, args);
                 ensureWidget(this);
+                return res;
+            };
+
+            const originalOnDrawForeground = nodeType.prototype.onDrawForeground;
+            nodeType.prototype.onDrawForeground = function (...args) {
+                const res = originalOnDrawForeground?.apply(this, args);
+                const info = activeWidgets.get(this.id);
+                if (!info) return res;
+
+                const zoom = getCanvasZoom();
+                if (info.lastZoom !== zoom) {
+                    info.lastZoom = zoom;
+                    requestLayoutUpdate(this);
+                }
+
                 return res;
             };
         }

--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -241,8 +241,10 @@ function ensureStyles() {
         flex-direction: column;
         gap: 8px;
         width: 100%;
+        height: 100%;
         box-sizing: border-box;
         padding: 12px;
+        overflow: hidden;
     }
     .cg-chooser-grid-stage {
         flex: 1;
@@ -252,11 +254,15 @@ function ensureStyles() {
         align-items: center;
         justify-content: center;
         position: relative;
+        overflow: hidden;
     }
     .cg-chooser-grid {
         display: grid;
         gap: 6px;
         width: 100%;
+        max-width: 100%;
+        max-height: 100%;
+        overflow: hidden;
     }
     .cg-chooser-cell {
         position: relative;
@@ -282,9 +288,11 @@ function ensureStyles() {
     }
     .cg-chooser-footer {
         display: flex;
+        flex: 0 0 auto;
         justify-content: flex-end;
         gap: 8px;
         margin-top: 4px;
+        overflow: hidden;
     }
     .cg-chooser-footer button {
         border: none;
@@ -643,11 +651,7 @@ function applyLayout(node, detail, info, options = {}) {
     grid.style.alignContent = "center";
     grid.style.transform = "scale(1)";
 
-    const nodeHeight = Number(node.size?.[1]);
-    const enforceMinHeight = node._ic_userSized
-        ? Math.min(layout.preferredHeight, Number.isFinite(nodeHeight) ? nodeHeight : layout.preferredHeight)
-        : layout.preferredHeight;
-    container.style.minHeight = `${Math.max(0, enforceMinHeight)}px`;
+    container.style.minHeight = "0px";
 
     if (info.domWidget) {
         info.domWidget.computeSize = () => [layout.preferredWidth, layout.preferredHeight];


### PR DESCRIPTION
This PR takes care of a few small quality of life things

### Caching
A new mode that plays well with Comfy's caching AND pauses the workflow when images change. The Repeat Last Selection mode is currently the only mode that doesn't cause downstreams to re-run, but once a selection is made, it is always taken even if the inputs change. This new mode works the same way, except it will detect if the input images have changed and pause the workflow for a selection to be made. Assuming the same inputs are provided in future runs, the selection holds.

Works well for workflows that have post-selection activities (upscale) where you may want to tweak denoise settings and not have to reset the mode manually when changing the inputs.

### Node Descriptions
I kept getting mixed up between which node does the overlay and which node was inline, so fixed the descriptions that appear in the add node dialog

### Fix Scrolling and Panning
As reported in #7, mouse events were not propagated to the Comfy canvas which caused strange behavior if the node was under the cursor at the time the event fired. Scroll in/out and pan events were broken.

### Right Click
Since mouse events weren't making it "upstream", I noticed I couldn't *do* anything with the image thumbnail. Once propagation was fixed, we started getting just the ComfyUI node's context menu. Added a small QoL feater (configurable in settings) to have a right click default to your browser menu, the ComfyUI node context menu, or just open it in a new tab.

### Alert Sound
The alert sound only worked for the overlay node. I am assuming that was not intentional, so have patched it to work consistently for all of the nodes.

### Rerun button
In addition to the Cancel and Progress buttons, there is now a Rerun button. This does the same thing as Cancel, but it also queues the workflow to run again. This is handy if you're using a new random seed on each run and you don't like any of the outputs presented.

I've tested each of these locally on a Windows and Linux machines. Passes muster from what I can tell.