### PR TITLE
Last fix for inline chooser layout

### DIFF
--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -629,13 +629,13 @@ function applyLayout(node, detail, info, options = {}) {
     grid.style.gridAutoRows = formatPx(cellHeight);
     grid.style.columnGap = formatPx(columnGap);
     grid.style.rowGap = formatPx(rowGap);
-    grid.style.width = formatPx(usedWidth);
+    grid.style.width = "100%";
     grid.style.height = formatPx(usedHeight);
     grid.style.maxHeight = formatPx(usedHeight);
-    grid.style.maxWidth = formatPx(usedWidth);
-    grid.style.minWidth = formatPx(usedWidth);
+    grid.style.maxWidth = "100%";
+    grid.style.minWidth = "0px";
     grid.style.minHeight = formatPx(usedHeight);
-    grid.style.margin = "0 auto";
+    //grid.style.margin = "0 auto";
     grid.style.justifyContent = "center";
     grid.style.alignContent = "center";
     grid.style.transform = "scale(1)";
@@ -643,7 +643,10 @@ function applyLayout(node, detail, info, options = {}) {
     container.style.minHeight = "0px";
 
     if (info.domWidget) {
-        info.domWidget.computeSize = () => [layout.preferredWidth, layout.preferredHeight];
+        // Always report the current node width back unchanged so ComfyUI never
+        // uses computeSize to resize the node horizontally.  Only the height
+        // hint is ours to control.
+        info.domWidget.computeSize = (width) => [width, layout.preferredHeight];
     }
 
     if (!node._ic_userSized && options.allowSizeUpdate !== false) {

--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -632,14 +632,16 @@ function applyLayout(node, detail, info, options = {}) {
     grid.style.width = "100%";
     grid.style.height = formatPx(usedHeight);
     grid.style.maxHeight = formatPx(usedHeight);
-    grid.style.maxWidth = "100%";
-    grid.style.minWidth = "0px";
-    grid.style.minHeight = formatPx(usedHeight);
-    //grid.style.margin = "0 auto";
+    grid.style.maxWidth = formatPx(usedWidth);
+    grid.style.minWidth = "0";
+    grid.style.minHeight = "0";
+    grid.style.overflow = "hidden";
+    grid.style.margin = "0 auto";
     grid.style.justifyContent = "center";
     grid.style.alignContent = "center";
     grid.style.transform = "scale(1)";
 
+    if (stage) stage.style.overflow = "hidden";
     container.style.minHeight = "0px";
 
     if (info.domWidget) {

--- a/js/image_chooser_widget.js
+++ b/js/image_chooser_widget.js
@@ -633,14 +633,23 @@ function applyLayout(node, detail, info, options = {}) {
     grid.style.height = formatPx(usedHeight);
     grid.style.maxHeight = formatPx(usedHeight);
     grid.style.maxWidth = formatPx(usedWidth);
-    grid.style.minWidth = formatPx(usedWidth);
-    grid.style.minHeight = formatPx(usedHeight);
+    grid.style.minWidth = "0";
+    grid.style.minHeight = "0";
+    grid.style.overflow = "hidden";
     grid.style.margin = "0 auto";
     grid.style.justifyContent = "center";
     grid.style.alignContent = "center";
     grid.style.transform = "scale(1)";
 
+    if (stage) stage.style.overflow = "hidden";
     container.style.minHeight = "0px";
+    // In app mode (ComfyUI "app view"), ComfyUI mounts our element inside a
+    // WidgetDOM wrapper div (class "flex flex-col *:flex-1") that has no
+    // overflow:hidden. Propagate the hidden overflow upward whenever the
+    // element has been mounted into a parent so that wrapper can never scroll.
+    if (container.parentElement instanceof HTMLElement) {
+        container.parentElement.style.overflow = "hidden";
+    }
 
     if (info.domWidget) {
         info.domWidget.computeSize = () => [layout.preferredWidth, layout.preferredHeight];
@@ -712,7 +721,6 @@ function renderChooser(node, detail) {
     rerunBtn.textContent = "Rerun";
     rerunBtn.addEventListener("click", () => {
         send_cancel();
-        clearSelection(node);
         app.queuePrompt(0, 1);
     });
 
@@ -808,7 +816,6 @@ function sendSelection(node) {
     if (sel.length === 0) return;
     sel.sort((a, b) => a - b);
     send_message(target, sel.join(","));
-    clearSelection(node);
 }
 
 function handleEvent(detail) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "image-chooser-classic"
 description = "A modern re-implementation of the classic [a/cg-image-picker](https://github.com/chrisgoringe/cg-image-picker) ComfyUI nodes. Keep the workflow-pausing image selection experience while shedding the legacy compatibility shims."
-version = "1.1.3"
+version = "1.1.4"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
Fixes two last bits: prevents layout jumping a little when clicking on the widget items and avoids scrollbars from ever appearing due to sub-pixel calculations leaving a single extra pixel.